### PR TITLE
Added reward types and support for custom background and font colors

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,17 +4,21 @@
 
 ### Common changes
 
+- Added support for custom background texture and font colors for quest details window in quest log menu
+- Added support for new types of quest reward: `Object` and `Weapon`
 - Fixed some issues with multiplayer
 - Write quest type classes in console for `quests_list`, `quests_log` and `quests_customtypes`
 - Added new command `quests_customtypes`
 
 ### For Content Pack modders
 
+- Added new fields for quest: `RewardType`, `RewardAmount`, `Texture` and `Colors`
 - Added support for custom quest types in content packs (via `<modUid>/<questTypeName>` in `Type` field)
 - Better error messages
 
 ### For SMAPI modders
 
+- Added new APIs for define quest reward type, custom bg texture nad font colors
 - Added new APIs for expose custom quest types (class)
 - Exposed `ITriggerLoader` interface
 

--- a/docs/content-pack-guide.md
+++ b/docs/content-pack-guide.md
@@ -1,4 +1,5 @@
-﻿← [README](../README.md)
+﻿
+← [README](../README.md)
 
 # Content pack guide
 
@@ -32,7 +33,7 @@ Create your `manifest.json` file which must contains these minimum contents:
   "UpdateKeys": [],
   "ContentPackFor": {
     "UniqueID": "PurrplingCat.QuestFramework", // Quest Framework unique id must be here
-    "MinimumVersion": "1.1.0" // optional
+    "MinimumVersion": "1.2.0" // optional
   }
 }
 ```
@@ -61,21 +62,25 @@ In the `Quests` section you can define one ore more custom quests. Quest definit
 
 Field             | Required? | Description 
 ----------------- | --------- | -----------
-Name              | required  | (string) Name (UID) of your quest (this never shows to player)
-Type              | required  | (string) Vanilla SDV quest type (see quest type)
-CustomTypeId      |           | (int) Custom Quest type id (see custom quest types in advanced API). Can be handled by any other mod.
-Title             | required  | (string) Quest title in the quest log
-Description       |           | (string) Quest description
-Objective         | required  | (string) Quest objective
-NextQuests        |           | (string[]) One of more next quests which will be added to player's quest log when this quest is completed.
-DaysLeft          |           | (int) If this field is filled or is greater than 0, this quest is marked as daily and limited for specified number of days here.
-Reward            |           | (int) Reward in SDV currency "golds". If this field is not defined or has value `0`, then player will receive no money reward.
-RewardDescription |           | (string) Reward description
-Cancelable        |           | (boolean) Can player cancel this quest?
-ReactionText      |           | (string) NPC's reaction text when you complete this quest (only for quests which interacts with NPCs)
-Trigger           |           | (string) Completion trigger (see quest types for more info) Supports [JSON Assets](#json-assets-support)
-Hooks             |           | (Hook) Quest hooks (see hooks for more info)
-ConversationTopic |           | (ConversationTopic) Add or remove conversation topic (see conversation topic for more info)
+Name              | required  | `string` Name (UID) of your quest (this never shows to player)
+Type              | required  | `string` Vanilla SDV quest type (see quest type)
+CustomTypeId      |           | `int` Custom Quest type id (see custom quest types in advanced API). Can be handled by any other mod.
+Title             | required  | `string` Quest title in the quest log
+Description       |           | `string` Quest description
+Objective         | required  | `string` Quest objective
+NextQuests        |           | `string[]` One of more next quests which will be added to player's quest log when this quest is completed.
+DaysLeft          |           | `int` If this field is filled or is greater than 0, this quest is marked as daily and limited for specified number of days here.
+Reward            |           | `int|string` Reward in SDV currency "golds". If this field is not defined or has value `0`, then player will receive no money reward.
+RewardType        |           | `RewardType` Type of [reward for player](#Rewards). (default: *Money*)
+RewardAmount      |           | `int` Amount of reward items. Only for `Object` reward type.
+RewardDescription |           | `string` Reward description
+Cancelable        |           | `boolean` Can player cancel this quest?
+ReactionText      |           | `string` NPC's reaction text when you complete this quest (only for quests which interacts with NPCs)
+Trigger           |           | `string` Completion trigger (see quest types for more info) Supports [JSON Assets](#json-assets-support)
+Texture           |           | `string` Path to PNG file with custom background texture for this quest in quest log menu. Path is relative to your content pack root directory.
+Colors            |           | `QuestLogColors` Settings of font colors for this quest in the quest log menu.
+Hooks             |           | `Hook` Quest hooks (see hooks for more info)
+ConversationTopic |           | `ConversationTopic` Add or remove conversation topic (see conversation topic for more info)
 
 #### Example
 
@@ -91,6 +96,7 @@ ConversationTopic |           | (ConversationTopic) Add or remove conversation t
       "Objective": "Bring amethyst to Abigail",
       "DaysLeft": 5, // If player don't complete this quest until 5 days, this quest will be removed from quest log automatically without completion
       "Reward": 300, // 300g
+      "RewardType": "Money",
       "Cancelable": true, // This quest can be cancelled by player
       "Trigger": "Abigail 66", // Bring amethyst to Abby
       "ReactionText": "Oh, it's looks delicious. I am really hungry."
@@ -168,6 +174,131 @@ Same usage as *LostItem*
 Custom quest type. You can specify field `CustomTypeId` for more explicit which custom quest type. In JSON api you can use hooks to create custom quest handling.
 
 *Trigger*: Custom defined. In JSON api use hooks instead for handle your pure JSON custom quest. If you target a custom quest type defined by any other mod in your JSON content pack, follow instructions of the source mod of this quest type.
+
+### Rewards
+
+There are supported some reward types for quests. You can specify reward type in field `RewardType` in your quest definition. Reward is paid to player after quest is completed by clicking the reward in questlog menu (in quest details for completed quest)
+
+Reward type | Description
+----------- | -----------
+Money       | Amount of money player earn by complete this quest
+Object      | Which item player gets by complete this quest. You can specify your item by name (JSON assets items supported) or via their id (integer). Also you can specify amount (stack) of this item in field `RewardAmount`
+Weapon      | Which weapon player gets by complete this quest. You can specify your weapon by name (JSON assets items supported) or via their id (integer)
+
+#### Examples
+
+```js
+{
+  "Format": "1.0",
+  "Quests": [
+    {
+      "Name": "abigail_amethyst1",
+      "Type": "ItemDelivery",
+      "Title": "The purple lunch",
+      "Description": "Abigail are very hungry. She wants to eat something special from mines.",
+      "Objective": "Bring amethyst to Abigail",
+      "DaysLeft": 5,
+      "Reward": "Chocolate Cake",
+      "RewardType": "Object"
+      "RewardAmount": 2, // Player gets two chocolate cakes after complete this quest
+      "Cancelable": true, // This quest can be cancelled by player
+      "Trigger": "Abigail 66", // Bring amethyst to Abby
+      "ReactionText": "Oh, it's looks delicious. I am really hungry."
+    },
+    {
+      "Name": "abigail_amethyst2",
+      "Type": "ItemDelivery",
+      "Title": "The purple lunch again",
+      "Description": "Abigail are very hungry. She wants to eat something special from mines.",
+      "Objective": "Bring amethyst to Abigail",
+      "DaysLeft": 3,
+      "Reward": "Emerald", // Reward is 1x emerald for this quest
+      "RewardType": "Object"
+      "Cancelable": true, // This quest can be cancelled by player
+      "Trigger": "Abigail 66", // Bring amethyst to Abby
+      "ReactionText": "Oh, it's looks delicious. I am really hungry."
+    },
+    {
+      "Name": "clint_copperbar",
+      "Type": "ItemDelivery",
+      "Title": "Clint needs a copper bar",
+      "Description": "Clint asked you if you can bring him a copper bar.",
+      "Objective": "Bring a copperbar to Clint",
+      "Reward": 320, // Reward is 320g
+      "RewardType": "Money"
+      "Cancelable": true,
+      "Trigger": "Clint 334", // Bring copper bar to Clint
+      "ReactionText": "Thanks."
+    },
+    {
+      "Name": "marlon_slay_bats",
+      "Type": "Monster",
+      "Title": "Dangerous mine bats",
+      "Description": "Marlon wants help with slay dangerous bats which threaten villagers in the mountains every night",
+      "Objective": "Slay 10 bats",
+      "DaysLeft": 2,
+      "Reward": "Pirate's Sword", // Pirate's Sword is an reward for this quest
+      "RewardType": "Weapon"
+      "Cancelable": true,
+      "Trigger": "Bat 10", // Kill 10 bats
+    }
+  ]
+}
+```
+
+### Colors & Texture
+
+Be different! You can specify background texture of quest details window in quest log menu. Just specify an relative path to your content pack root in field `Texture` for your quest. Also you can customize text colors for this quest with field `Colors`.
+
+Color property | Type   | Desription
+-------------- | ------ | ----------
+TitleColor     | `int`  | Color of quest title.
+TextColor      | `int`  | Standard quest color (for decription)
+ObjectiveColor | `int`  | Color of quest objective
+
+#### Available colors
+
+Color id | Description
+-------- | -----------
+0        | Black
+1        | Sky Blue
+2        | Red
+3        | Purple
+4        | White
+5        | Orange Red
+6        | Lime Green
+7        | Cyan
+8        | Grey
+
+#### Example
+
+```js
+{
+  "Format": "1.0",
+  "Quests": [
+    {
+      "Name": "abigail_amethyst", // No id needed, will be automatically generated
+      "Type": "ItemDelivery", // Vanilla quest type
+      "Title": "%i18n:abigail_amethyst.title",
+      "Description": "Abigail is very hungry. She wants to eat something special from mines.",
+      "Objective": "Bring amethyst to Abigail",
+      "DaysLeft": 10,
+      "Reward": 1000,
+      "RewardType": "Money",
+      "Cancelable": true,
+      "Trigger": "Abigail 66", // Bring amethyst to Abby
+      "ReactionText": "Oh, this looks so delicious. I am really hungry, thank you, @!$h",
+      "CustomField": "%i18n:custom.field",
+      "Texture": "assets/wizardQuest.png",
+      "Colors": {
+        "TitleColor": 4,
+        "TextColor": 4,
+        "ObjectiveColor": 1
+      }
+    }
+  ]
+}
+```
 
 ## Hooks
 
@@ -258,9 +389,9 @@ TouchAction     | Touch action property value must be this defined value for tri
 
 ## Conversation topic
 
-[Conversation topic] (https://stardewvalleywiki.com/Modding:Dialogue#Conversation_topics) can make the character speak of certain dialogue when the specific conversation topic is active. Please refer to the conversation topic explanation on the wiki before using this feature. With this field you can make NPCs give dialogue when a quest is accepted, cancelled, and or completed. The respective dialogue itself must be added using [Content patcher] (https://github.com/Pathoschild/StardewMods/blob/develop/ContentPatcher/docs/author-guide.md#editdata)
+[Conversation topic](https://stardewvalleywiki.com/Modding:Dialogue#Conversation_topics) can make the character speak of certain dialogue when the specific conversation topic is active. Please refer to the conversation topic explanation on the wiki before using this feature. With this field you can make NPCs give dialogue when a quest is accepted, cancelled, and or completed. The respective dialogue itself must be added using [Content patcher](https://github.com/Pathoschild/StardewMods/blob/develop/ContentPatcher/docs/author-guide.md#editdata)
 
-## Options 
+### Options 
 
 Valid field              | Example value              | Description
 ------------------------ | -------------------------- | -----------

--- a/src/Framework/ContentPacks/Loader.cs
+++ b/src/Framework/ContentPacks/Loader.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
+using Newtonsoft.Json.Linq;
 using PurrplingCore.Lexing;
 using PurrplingCore.Lexing.LexTokens;
 using QuestFramework.Framework.ContentPacks.Model;
@@ -276,11 +278,24 @@ namespace QuestFramework.Framework.ContentPacks
             managedQuest.Cancelable = questData.Cancelable;
             managedQuest.Trigger = this.ApplyTokens(trigger);
             managedQuest.NextQuests = questData.NextQuests;
+            managedQuest.Colors = questData.Colors;
             managedQuest.OwnedByModUid = content.Owner.Manifest.UniqueID;
 
             if (questData.CustomTypeId != -1)
             {
                 managedQuest.CustomTypeId = questData.CustomTypeId;
+            }
+
+            if (!string.IsNullOrEmpty(questData.Texture))
+            {
+                try
+                {
+                    managedQuest.Texture = content.Owner.LoadAsset<Texture2D>(questData.Texture);
+                } 
+                catch (ContentLoadException ex)
+                {
+                    this.Monitor.Log($"Couldn't load quest background texture file `{questData.Texture}`: {ex.Message}");
+                }
             }
 
             questData.PopulateExtendedData(managedQuest);

--- a/src/Framework/ContentPacks/Loader.cs
+++ b/src/Framework/ContentPacks/Loader.cs
@@ -269,6 +269,8 @@ namespace QuestFramework.Framework.ContentPacks
             managedQuest.Objective = questData.Objective;
             managedQuest.DaysLeft = questData.DaysLeft;
             managedQuest.Reward = questData.Reward;
+            managedQuest.RewardType = questData.RewardType;
+            managedQuest.RewardAmount = questData.RewardAmount;
             managedQuest.RewardDescription = questData.RewardDescription;
             managedQuest.ReactionText = questData.ReactionText;
             managedQuest.Cancelable = questData.Cancelable;

--- a/src/Framework/ContentPacks/Loader.cs
+++ b/src/Framework/ContentPacks/Loader.cs
@@ -8,6 +8,7 @@ using QuestFramework.Framework.Helpers;
 using QuestFramework.Offers;
 using QuestFramework.Quests;
 using StardewModdingAPI;
+using StardewValley;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -270,7 +271,7 @@ namespace QuestFramework.Framework.ContentPacks
             managedQuest.Description = questData.Description;
             managedQuest.Objective = questData.Objective;
             managedQuest.DaysLeft = questData.DaysLeft;
-            managedQuest.Reward = questData.Reward;
+            managedQuest.Reward = this.ParseReward(questData.Reward, questData.RewardType);
             managedQuest.RewardType = questData.RewardType;
             managedQuest.RewardAmount = questData.RewardAmount;
             managedQuest.RewardDescription = questData.RewardDescription;
@@ -301,6 +302,45 @@ namespace QuestFramework.Framework.ContentPacks
             questData.PopulateExtendedData(managedQuest);
 
             return managedQuest;
+        }
+
+        private int ParseReward(JToken reward, RewardType rewardType)
+        {
+            if (reward != null)
+            {
+                if (reward.Type == JTokenType.Integer)
+                {
+                    return reward.ToObject<int>();
+                }
+
+                int id;
+                string rewardName = reward.ToObject<string>();
+                switch (rewardType)
+                {
+                    case RewardType.Money:
+                        return reward.ToObject<int>();
+                    case RewardType.Object:
+                        id = ItemHelper.GetObjectId(rewardName);
+
+                        if (id == -1)
+                        {
+                            this.Monitor.Log($"Unknown object `{rewardName}` for quest reward.", LogLevel.Error);
+                        }
+
+                        return id;
+                    case RewardType.Weapon:
+                        id = ItemHelper.GetWeaponId(rewardName);
+
+                        if (id == -1)
+                        {
+                            this.Monitor.Log($"Unknown weapon `{rewardName}` for quest reward.", LogLevel.Error);
+                        }
+
+                        return id;
+                }
+            }
+
+            return 0;
         }
 
         private Content LoadContentPack(IContentPack contentPack)

--- a/src/Framework/ContentPacks/Model/QuestData.cs
+++ b/src/Framework/ContentPacks/Model/QuestData.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json.Linq;
 using QuestFramework.Hooks;
 using QuestFramework.Quests;
+using QuestFramework.Structures;
 using StardewModdingAPI;
 using System.Collections.Generic;
 
@@ -24,6 +25,8 @@ namespace QuestFramework.Framework.ContentPacks.Model
         public bool Cancelable { get; set; }
         public string ReactionText { get; set; }
         public JToken Trigger { get; set; }
+        public string Texture { get; set; }
+        public QuestLogColors Colors { get; set; }
         public List<Hook> Hooks { get; set; }
         public ConversationTopicData ConversationTopic { get; set; }
 

--- a/src/Framework/ContentPacks/Model/QuestData.cs
+++ b/src/Framework/ContentPacks/Model/QuestData.cs
@@ -18,6 +18,8 @@ namespace QuestFramework.Framework.ContentPacks.Model
         public List<string> NextQuests { get; set; }
         public int DaysLeft { get; set; }
         public int Reward { get; set; }
+        public RewardType RewardType { get; set; } = RewardType.Money;
+        public int RewardAmount { get; set; }
         public string RewardDescription { get; set; }
         public bool Cancelable { get; set; }
         public string ReactionText { get; set; }

--- a/src/Framework/ContentPacks/Model/QuestData.cs
+++ b/src/Framework/ContentPacks/Model/QuestData.cs
@@ -18,7 +18,7 @@ namespace QuestFramework.Framework.ContentPacks.Model
         public string Objective { get; set; }
         public List<string> NextQuests { get; set; }
         public int DaysLeft { get; set; }
-        public int Reward { get; set; }
+        public JToken Reward { get; set; }
         public RewardType RewardType { get; set; } = RewardType.Money;
         public int RewardAmount { get; set; }
         public string RewardDescription { get; set; }

--- a/src/Framework/Helpers/ItemHelper.cs
+++ b/src/Framework/Helpers/ItemHelper.cs
@@ -1,0 +1,46 @@
+﻿using StardewValley;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuestFramework.Framework.Helpers
+{
+    internal static class ItemHelper
+    {
+        public static int GetWeaponId(string swordIdName)
+        {
+            Dictionary<int, string> dictionary = Game1.content.Load<Dictionary<int, string>>("Data\\weapons");
+
+            if (int.TryParse(swordIdName, out int id))
+                return dictionary.Keys.Contains(id) ? id : -1;
+
+            var swordData = from s in dictionary
+                            where s.Value.StartsWith($"{swordIdName}/")
+                            select s.Key;
+
+            if (swordData.Any())
+                return swordData.First();
+
+            return -1;
+        }
+
+        public static int GetObjectId(string objIdName)
+        {
+            var dictionary = Game1.objectInformation;
+
+            if (int.TryParse(objIdName, out int id))
+                return dictionary.Keys.Contains(id) ? id : -1;
+
+            var objectData = from s in dictionary
+                            where s.Value.StartsWith($"{objIdName}/")
+                            select s.Key;
+
+            if (objectData.Any())
+                return objectData.First();
+
+            return -1;
+        }
+    }
+}

--- a/src/Framework/Menus/ManagedQuestLog.cs
+++ b/src/Framework/Menus/ManagedQuestLog.cs
@@ -1,0 +1,222 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using PurrplingCore;
+using QuestFramework.Extensions;
+using QuestFramework.Quests;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.BellsAndWhistles;
+using StardewValley.Menus;
+using StardewValley.Quests;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace QuestFramework.Framework.Menus
+{
+    internal class ManagedQuestLog : QuestLog
+    {
+        protected internal static IReflectionHelper Reflection => QuestFrameworkMod.Instance.Helper.Reflection;
+
+        private int lastQuestPage = -1;
+        private Item rewardItem;
+
+        private List<List<Quest>> Pages => Reflection.GetField<List<List<Quest>>>(this, "pages").GetValue();
+        private int QuestPage => Reflection.GetField<int>(this, "questPage").GetValue();
+        private int CurrentPage => Reflection.GetField<int>(this, "currentPage").GetValue();
+
+        public Quest CurrentQuest
+        {
+            get
+            {
+                if (this.Pages.ElementAtOrDefault(this.CurrentPage) == null || this.Pages[this.CurrentPage].ElementAtOrDefault(this.QuestPage) == null)
+                    return null;
+
+                return this.Pages[this.CurrentPage][this.QuestPage];
+            }
+        }
+
+        public override void update(GameTime time)
+        {
+            if (this.lastQuestPage != this.QuestPage)
+            {
+                this.lastQuestPage = this.QuestPage;
+                this.UpdateRewardBoxContent();
+            }
+
+            base.update(time);
+        }
+
+        public override void receiveLeftClick(int x, int y, bool playSound = true)
+        {
+            if (this.IsClickedOnRewardBox(x, y))
+            {
+                switch (this.CurrentQuest.AsManagedQuest().RewardType)
+                {
+                    case RewardType.Money:
+                        Game1.player.Money += this.CurrentQuest.moneyReward.Value;
+                        Game1.playSound("purchaseRepeat");
+                        break;
+                    case RewardType.Item:
+                        Game1.playSound("coin");
+                        Game1.player.addItemByMenuIfNecessary(this.rewardItem, (ItemGrabMenu.behaviorOnItemSelect)null);
+                        this.rewardItem = null;
+                        break;
+                }
+
+                this.CurrentQuest.moneyReward.Value = 0;
+                this.CurrentQuest.destroy.Value = true;
+
+                return;
+            }
+
+            base.receiveLeftClick(x, y, playSound);
+        }
+
+        private bool IsClickedOnRewardBox(int x, int y)
+        {
+            return this.QuestPage != -1 
+                && this.CurrentQuest.IsManaged()
+                && this.CurrentQuest.completed.Value 
+                && this.CurrentQuest.moneyReward.Value > 0 
+                && this.rewardBox.containsPoint(x, y);
+        }
+
+        private void UpdateRewardBoxContent()
+        {
+            var managedQuest = this.CurrentQuest?.AsManagedQuest();
+
+            if (managedQuest != null && managedQuest.RewardType == RewardType.Item)
+            {
+                this.rewardItem = new StardewValley.Object(
+                    Vector2.Zero, managedQuest.Reward, 
+                    managedQuest.RewardAmount > 0 ? managedQuest.RewardAmount : 1);
+            } else
+            {
+                this.rewardItem = null;
+            }
+        }
+
+        public override void draw(SpriteBatch b)
+        {
+            if (this.CurrentQuest != null && this.CurrentQuest.IsManaged())
+            {
+                this.DrawWindow(b);
+                this.DrawManagedQuestDetails(b);
+                this.DrawCursors(b);
+
+                return;
+            }
+
+            base.draw(b);
+        }
+
+        private void DrawCursors(SpriteBatch b)
+        {
+            if (this.upperRightCloseButton != null || this.shouldDrawCloseButton())
+            {
+                this.upperRightCloseButton.draw(b);
+            }
+
+            if (this.QuestPage != -1)
+            {
+                this.backButton.draw(b);
+            }
+
+            Game1.mouseCursorTransparency = 1f;
+            this.drawMouse(b);
+
+            var hoverText = Reflection.GetField<string>(this, "hoverText").GetValue();
+            if (hoverText.Length > 0)
+            {
+                drawHoverText(b, hoverText, Game1.dialogueFont);
+            }
+        }
+
+        private void DrawWindow(SpriteBatch b)
+        {
+            b.Draw(Game1.fadeToBlackRect, Game1.graphics.GraphicsDevice.Viewport.Bounds, Color.Black * 0.75f);
+            SpriteText.drawStringWithScrollCenteredAt(
+                b, Game1.content.LoadString("Strings\\StringsFromCSFiles:QuestLog.cs.11373"),
+                this.xPositionOnScreen + (this.width / 2), this.yPositionOnScreen - 64, "", 1f, -1, 0, 0.88f, false);
+            drawTextureBox(
+                b, Game1.mouseCursors, new Rectangle(384, 373, 18, 18), this.xPositionOnScreen, this.yPositionOnScreen,
+                this.width, this.height, Color.White, 4f, true);
+        }
+
+        private void DrawManagedQuestDetails(SpriteBatch b)
+        {
+            SpriteText.drawStringHorizontallyCenteredAt(
+                b, this.CurrentQuest.questTitle,
+                this.xPositionOnScreen
+                + (this.width / 2)
+                + (!this.CurrentQuest.dailyQuest.Value || this.CurrentQuest.daysLeft.Value <= 0 ? 0 : Math.Max(
+                    32, SpriteText.getWidthOfString(this.CurrentQuest.questTitle, 999999) / 3) - 32),
+                this.yPositionOnScreen + 32, 999999, -1, 999999, 1f, 0.88f, false, -1, 99999);
+
+            if (this.CurrentQuest.dailyQuest.Value && this.CurrentQuest.daysLeft.Value > 0)
+            {
+                Utility.drawWithShadow(b, Game1.mouseCursors,
+                    new Vector2(this.xPositionOnScreen + 32, this.yPositionOnScreen + 48 - 8),
+                    new Rectangle(410, 501, 9, 9), Color.White, 0.0f, Vector2.Zero, 4f, false, 0.99f, -1, -1, 0.35f);
+                Utility.drawTextWithShadow(
+                    b,
+                    Game1.parseText(this.CurrentQuest.daysLeft.Value > 1 
+                        ? Game1.content.LoadString(@"Strings\StringsFromCSFiles:QuestLog.cs.11374", this.CurrentQuest.daysLeft.Value)
+                        : Game1.content.LoadString(@"Strings\StringsFromCSFiles:QuestLog.cs.11375", this.CurrentQuest.daysLeft.Value), 
+                    Game1.dialogueFont, this.width - 128),
+                    Game1.dialogueFont, new Vector2(this.xPositionOnScreen + 80, this.yPositionOnScreen + 48 - 8),
+                    Game1.textColor, 1f, -1f, -1, -1, 1f, 3);
+            }
+            Utility.drawTextWithShadow(b, Game1.parseText(this.CurrentQuest.questDescription, Game1.dialogueFont, this.width - 128), Game1.dialogueFont, new Vector2(this.xPositionOnScreen + 64, this.yPositionOnScreen + 96), Game1.textColor, 1f, -1f, -1, -1, 1f, 3);
+            float y = (float)(this.yPositionOnScreen + 96 + (double)Game1.dialogueFont.MeasureString(Game1.parseText(this.CurrentQuest.questDescription, Game1.dialogueFont, this.width - 128)).Y + 32.0);
+            if (this.CurrentQuest.completed.Value)
+            {
+                SpriteText.drawString(b, Game1.content.LoadString("Strings\\StringsFromCSFiles:QuestLog.cs.11376"), this.xPositionOnScreen + 32 + 4, this.rewardBox.bounds.Y + 21 + 4, 999999, -1, 999999, 1f, 0.88f, false, -1, "", -1, SpriteText.ScrollTextAlignment.Left);
+                this.rewardBox.draw(b);
+
+                if (this.CurrentQuest.moneyReward.Value <= 0)
+                {
+                    return;
+                }
+
+                if (this.CurrentQuest.AsManagedQuest().RewardType == RewardType.Item && this.rewardItem != null)
+                {
+                    this.rewardItem.drawInMenu(
+                        b, new Vector2(this.rewardBox.bounds.X + 18, this.rewardBox.bounds.Y + 18 - Game1.dialogueButtonScale / 6f), 0.9f + this.rewardBox.scale * 0.03f);
+                    SpriteText.drawString(b,
+                        Utils.CutText(this.rewardItem.DisplayName, 15),
+                        this.xPositionOnScreen + 448, this.rewardBox.bounds.Y + 21 + 4, 999999, -1, 999999, 1f, 0.88f,
+                        false, -1, "", -1, SpriteText.ScrollTextAlignment.Left);
+                }
+                else if (this.CurrentQuest.AsManagedQuest().RewardType == RewardType.Money)
+                {
+                    b.Draw(Game1.mouseCursors,
+                           new Vector2(this.rewardBox.bounds.X + 16, this.rewardBox.bounds.Y + 16 - Game1.dialogueButtonScale / 2f),
+                           new Rectangle?(new Rectangle(280, 410, 16, 16)), Color.White, 0.0f, Vector2.Zero, 4f,
+                           SpriteEffects.None, 1f);
+                    SpriteText.drawString(b,
+                        Game1.content.LoadString("Strings\\StringsFromCSFiles:LoadGameMenu.cs.11020", this.CurrentQuest.moneyReward.Value),
+                        this.xPositionOnScreen + 448, this.rewardBox.bounds.Y + 21 + 4, 999999, -1, 999999, 1f, 0.88f,
+                        false, -1, "", -1, SpriteText.ScrollTextAlignment.Left);
+                }
+            }
+            else
+            {
+                Utility.drawWithShadow(
+                    b, Game1.mouseCursors,
+                    new Vector2(this.xPositionOnScreen + 96 + (float)(8.0 * Game1.dialogueButtonScale / 10.0), y),
+                    new Rectangle(412, 495, 5, 4), Color.White, 1.570796f, Vector2.Zero, -1f, false, -1f, -1, -1, 0.35f);
+                Utility.drawTextWithShadow(b,
+                    Game1.parseText(this.CurrentQuest.currentObjective, Game1.dialogueFont, this.width - 256),
+                    Game1.dialogueFont, new Vector2(this.xPositionOnScreen + 128, y - 8f), Color.DarkBlue, 1f, -1f, -1,
+                    -1, 1f, 3);
+
+                if (this.CurrentQuest.canBeCancelled.Value)
+                {
+                    this.cancelQuestButton.draw(b);
+                }
+            }
+        }
+    }
+}

--- a/src/Framework/Menus/ManagedQuestLog.cs
+++ b/src/Framework/Menus/ManagedQuestLog.cs
@@ -95,7 +95,6 @@ namespace QuestFramework.Framework.Menus
             var managedQuest = this.CurrentQuest?.AsManagedQuest();
 
             this.rewardItem = null;
-            this.learnedRecipe = null;
 
             switch (managedQuest?.RewardType)
             {

--- a/src/Framework/Menus/ManagedQuestLog.cs
+++ b/src/Framework/Menus/ManagedQuestLog.cs
@@ -139,40 +139,80 @@ namespace QuestFramework.Framework.Menus
             SpriteText.drawStringWithScrollCenteredAt(
                 b, Game1.content.LoadString("Strings\\StringsFromCSFiles:QuestLog.cs.11373"),
                 this.xPositionOnScreen + (this.width / 2), this.yPositionOnScreen - 64, "", 1f, -1, 0, 0.88f, false);
-            drawTextureBox(
-                b, Game1.mouseCursors, new Rectangle(384, 373, 18, 18), this.xPositionOnScreen, this.yPositionOnScreen,
-                this.width, this.height, Color.White, 4f, true);
+
+            if (this.QuestPage != -1 && this.CurrentQuest.IsManaged() && this.CurrentQuest.AsManagedQuest().Texture != null)
+            {
+                b.Draw(
+                    texture: this.CurrentQuest.AsManagedQuest().Texture,
+                    destinationRectangle: new Rectangle(this.xPositionOnScreen,this.yPositionOnScreen, this.width, this.height),
+                    color: Color.White);
+            }
+            else
+            {
+                drawTextureBox(
+                    b, Game1.mouseCursors, new Rectangle(384, 373, 18, 18), this.xPositionOnScreen, this.yPositionOnScreen,
+                    this.width, this.height, Color.White, 4f, true);
+            }
         }
 
         private void DrawManagedQuestDetails(SpriteBatch b)
         {
+            var managedQuest = this.CurrentQuest.AsManagedQuest();
+
             SpriteText.drawStringHorizontallyCenteredAt(
                 b, this.CurrentQuest.questTitle,
                 this.xPositionOnScreen
                 + (this.width / 2)
                 + (!this.CurrentQuest.dailyQuest.Value || this.CurrentQuest.daysLeft.Value <= 0 ? 0 : Math.Max(
                     32, SpriteText.getWidthOfString(this.CurrentQuest.questTitle, 999999) / 3) - 32),
-                this.yPositionOnScreen + 32, 999999, -1, 999999, 1f, 0.88f, false, -1, 99999);
+                this.yPositionOnScreen + 32, 
+                color: managedQuest.Colors?.TitleColor ?? -1);
 
             if (this.CurrentQuest.dailyQuest.Value && this.CurrentQuest.daysLeft.Value > 0)
             {
                 Utility.drawWithShadow(b, Game1.mouseCursors,
                     new Vector2(this.xPositionOnScreen + 32, this.yPositionOnScreen + 48 - 8),
                     new Rectangle(410, 501, 9, 9), Color.White, 0.0f, Vector2.Zero, 4f, false, 0.99f, -1, -1, 0.35f);
-                Utility.drawTextWithShadow(
-                    b,
-                    Game1.parseText(this.CurrentQuest.daysLeft.Value > 1 
-                        ? Game1.content.LoadString(@"Strings\StringsFromCSFiles:QuestLog.cs.11374", this.CurrentQuest.daysLeft.Value)
-                        : Game1.content.LoadString(@"Strings\StringsFromCSFiles:QuestLog.cs.11375", this.CurrentQuest.daysLeft.Value), 
-                    Game1.dialogueFont, this.width - 128),
-                    Game1.dialogueFont, new Vector2(this.xPositionOnScreen + 80, this.yPositionOnScreen + 48 - 8),
-                    Game1.textColor, 1f, -1f, -1, -1, 1f, 3);
+
+                if (managedQuest.Colors != null && managedQuest.Colors.ObjectiveColor != -1)
+                {
+                    b.DrawString(Game1.dialogueFont,
+                        Game1.parseText(this.CurrentQuest.daysLeft.Value > 1
+                            ? Game1.content.LoadString(@"Strings\StringsFromCSFiles:QuestLog.cs.11374", this.CurrentQuest.daysLeft.Value)
+                            : Game1.content.LoadString(@"Strings\StringsFromCSFiles:QuestLog.cs.11375", this.CurrentQuest.daysLeft.Value),
+                            Game1.dialogueFont, this.width - 128),
+                        new Vector2(this.xPositionOnScreen + 80, this.yPositionOnScreen + 48 - 8),
+                        SpriteText.getColorFromIndex(managedQuest.Colors.ObjectiveColor),
+                        0.0f, Vector2.Zero, 1f, SpriteEffects.None, 1f);
+                }
+                else
+                {
+                    Utility.drawTextWithShadow(
+                        b,
+                        Game1.parseText(this.CurrentQuest.daysLeft.Value > 1
+                            ? Game1.content.LoadString(@"Strings\StringsFromCSFiles:QuestLog.cs.11374", this.CurrentQuest.daysLeft.Value)
+                            : Game1.content.LoadString(@"Strings\StringsFromCSFiles:QuestLog.cs.11375", this.CurrentQuest.daysLeft.Value),
+                            Game1.dialogueFont, this.width - 128),
+                        Game1.dialogueFont, new Vector2(this.xPositionOnScreen + 80, this.yPositionOnScreen + 48 - 8),
+                        Game1.textColor, 1f, -1f, -1, -1, 1f, 3);
+                }
             }
-            Utility.drawTextWithShadow(b, Game1.parseText(this.CurrentQuest.questDescription, Game1.dialogueFont, this.width - 128), Game1.dialogueFont, new Vector2(this.xPositionOnScreen + 64, this.yPositionOnScreen + 96), Game1.textColor, 1f, -1f, -1, -1, 1f, 3);
+
+            if (managedQuest.Colors != null && managedQuest.Colors.TextColor != -1)
+            {
+                b.DrawString(Game1.dialogueFont, Game1.parseText(this.CurrentQuest.questDescription, Game1.dialogueFont, this.width - 128), new Vector2(this.xPositionOnScreen + 64, this.yPositionOnScreen + 96), SpriteText.getColorFromIndex(managedQuest.Colors.TextColor), 0.0f, Vector2.Zero, 1f, SpriteEffects.None, 1f);
+            }
+            else
+            {
+                Utility.drawTextWithShadow(b, Game1.parseText(this.CurrentQuest.questDescription, Game1.dialogueFont, this.width - 128), Game1.dialogueFont, new Vector2(this.xPositionOnScreen + 64, this.yPositionOnScreen + 96),
+                    managedQuest.Colors != null ? SpriteText.getColorFromIndex(managedQuest.Colors.TextColor) : Game1.textColor,
+                    1f, -1f, -1, -1, 1f, 3);
+            }
+
             float y = (float)(this.yPositionOnScreen + 96 + (double)Game1.dialogueFont.MeasureString(Game1.parseText(this.CurrentQuest.questDescription, Game1.dialogueFont, this.width - 128)).Y + 32.0);
             if (this.CurrentQuest.completed.Value)
             {
-                SpriteText.drawString(b, Game1.content.LoadString("Strings\\StringsFromCSFiles:QuestLog.cs.11376"), this.xPositionOnScreen + 32 + 4, this.rewardBox.bounds.Y + 21 + 4, 999999, -1, 999999, 1f, 0.88f, false, -1, "", -1, SpriteText.ScrollTextAlignment.Left);
+                SpriteText.drawString(b, Game1.content.LoadString("Strings\\StringsFromCSFiles:QuestLog.cs.11376"), this.xPositionOnScreen + 32 + 4, this.rewardBox.bounds.Y + 21 + 4, color: managedQuest.Colors?.TitleColor ?? -1);
                 this.rewardBox.draw(b);
 
                 if (this.CurrentQuest.moneyReward.Value <= 0)
@@ -180,16 +220,16 @@ namespace QuestFramework.Framework.Menus
                     return;
                 }
 
-                if (this.CurrentQuest.AsManagedQuest().RewardType == RewardType.Item && this.rewardItem != null)
+                if (managedQuest.RewardType == RewardType.Item && this.rewardItem != null)
                 {
                     this.rewardItem.drawInMenu(
                         b, new Vector2(this.rewardBox.bounds.X + 18, this.rewardBox.bounds.Y + 18 - Game1.dialogueButtonScale / 6f), 0.9f + this.rewardBox.scale * 0.03f);
                     SpriteText.drawString(b,
                         Utils.CutText(this.rewardItem.DisplayName, 15),
-                        this.xPositionOnScreen + 448, this.rewardBox.bounds.Y + 21 + 4, 999999, -1, 999999, 1f, 0.88f,
-                        false, -1, "", -1, SpriteText.ScrollTextAlignment.Left);
+                        this.xPositionOnScreen + 448, this.rewardBox.bounds.Y + 21 + 4,
+                        color: managedQuest.Colors?.TitleColor ?? -1);
                 }
-                else if (this.CurrentQuest.AsManagedQuest().RewardType == RewardType.Money)
+                else if (managedQuest.RewardType == RewardType.Money)
                 {
                     b.Draw(Game1.mouseCursors,
                            new Vector2(this.rewardBox.bounds.X + 16, this.rewardBox.bounds.Y + 16 - Game1.dialogueButtonScale / 2f),
@@ -197,8 +237,8 @@ namespace QuestFramework.Framework.Menus
                            SpriteEffects.None, 1f);
                     SpriteText.drawString(b,
                         Game1.content.LoadString("Strings\\StringsFromCSFiles:LoadGameMenu.cs.11020", this.CurrentQuest.moneyReward.Value),
-                        this.xPositionOnScreen + 448, this.rewardBox.bounds.Y + 21 + 4, 999999, -1, 999999, 1f, 0.88f,
-                        false, -1, "", -1, SpriteText.ScrollTextAlignment.Left);
+                        this.xPositionOnScreen + 448, this.rewardBox.bounds.Y + 21 + 4,
+                        color: managedQuest.Colors?.TitleColor ?? -1);
                 }
             }
             else
@@ -207,10 +247,23 @@ namespace QuestFramework.Framework.Menus
                     b, Game1.mouseCursors,
                     new Vector2(this.xPositionOnScreen + 96 + (float)(8.0 * Game1.dialogueButtonScale / 10.0), y),
                     new Rectangle(412, 495, 5, 4), Color.White, 1.570796f, Vector2.Zero, -1f, false, -1f, -1, -1, 0.35f);
-                Utility.drawTextWithShadow(b,
-                    Game1.parseText(this.CurrentQuest.currentObjective, Game1.dialogueFont, this.width - 256),
-                    Game1.dialogueFont, new Vector2(this.xPositionOnScreen + 128, y - 8f), Color.DarkBlue, 1f, -1f, -1,
-                    -1, 1f, 3);
+
+                if (managedQuest.Colors != null && managedQuest.Colors.ObjectiveColor != -1)
+                {
+                    b.DrawString(Game1.dialogueFont,
+                        Game1.parseText(this.CurrentQuest.currentObjective, Game1.dialogueFont, this.width - 128),
+                        new Vector2(this.xPositionOnScreen + 128, y - 8f),
+                        SpriteText.getColorFromIndex(managedQuest.Colors.ObjectiveColor),
+                        0.0f, Vector2.Zero, 1f, SpriteEffects.None, 1f);
+                }
+                else
+                {
+                    Utility.drawTextWithShadow(b,
+                        Game1.parseText(this.CurrentQuest.currentObjective, Game1.dialogueFont, this.width - 256),
+                        Game1.dialogueFont, new Vector2(this.xPositionOnScreen + 128, y - 8f),
+                        managedQuest.Colors != null ? SpriteText.getColorFromIndex(managedQuest.Colors.ObjectiveColor) : Color.DarkBlue,
+                        1f, -1f, -1, -1, 1f, 3);
+                }
 
                 if (this.CurrentQuest.canBeCancelled.Value)
                 {

--- a/src/Framework/Watchdogs/QuestLogWatchdog.cs
+++ b/src/Framework/Watchdogs/QuestLogWatchdog.cs
@@ -11,8 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
+using SConstants = StardewModdingAPI.Constants;
 
 namespace QuestFramework.Framework.Watchdogs
 {
@@ -31,7 +30,7 @@ namespace QuestFramework.Framework.Watchdogs
 
             // QuestLog reference only for andoroid, 
             // other platform uses ElementChanged event on NetObjectList
-            if (Constants.TargetPlatform == GamePlatform.Android)
+            if (SConstants.TargetPlatform == GamePlatform.Android)
             {
                 modEvents.GameLoop.UpdateTicked += this.OnUpdateTicked;
                 modEvents.GameLoop.ReturnedToTitle += this.OnReturnedToTitle;
@@ -43,7 +42,7 @@ namespace QuestFramework.Framework.Watchdogs
             if (!Context.IsWorldReady)
                 return;
 
-            if (Constants.TargetPlatform == GamePlatform.Android)
+            if (SConstants.TargetPlatform == GamePlatform.Android)
                 this.LastQuestLog = new List<Quest>(Game1.player.questLog);
             else
                 this.RegisterNetListElementChangedEvent();

--- a/src/QuestFrameworkMod.cs
+++ b/src/QuestFrameworkMod.cs
@@ -7,6 +7,7 @@ using QuestFramework.Framework.ContentPacks;
 using QuestFramework.Framework.Controllers;
 using QuestFramework.Framework.Events;
 using QuestFramework.Framework.Hooks;
+using QuestFramework.Framework.Menus;
 using QuestFramework.Framework.Networing;
 using QuestFramework.Framework.Stats;
 using QuestFramework.Framework.Store;
@@ -246,6 +247,12 @@ namespace QuestFramework
 
         private void OnQuestLogMenuChanged(object sender, MenuChangedEventArgs e)
         {
+            if (e.NewMenu is QuestLog && !(e.NewMenu is ManagedQuestLog))
+            {
+                Game1.activeClickableMenu = new ManagedQuestLog();
+                return;
+            }
+
             if (e.NewMenu is QuestLog && !(e.OldMenu is QuestLog))
                 this.EventManager.QuestLogMenuOpen.Fire(new System.EventArgs(), this);
             if (!(e.NewMenu is QuestLog) && e.OldMenu is QuestLog)

--- a/src/Quests/CustomQuest.cs
+++ b/src/Quests/CustomQuest.cs
@@ -33,6 +33,7 @@ namespace QuestFramework.Quests
         public string Objective { get; set; }
         public List<string> NextQuests { get; set; }
         public int Reward { get; set; }
+        public RewardType RewardType { get; set; } = RewardType.Money;
         public string RewardDescription { get; set; }
         public bool Cancelable { get; set; }
         public string ReactionText { get; set; }
@@ -97,6 +98,8 @@ namespace QuestFramework.Quests
         internal protected static IModHelper Helper => QuestFrameworkMod.Instance.Helper;
         internal protected static IMonitor Monitor => QuestFrameworkMod.Instance.Monitor;
         private static StatsManager StatsManager => QuestFrameworkMod.Instance.StatsManager;
+
+        public int RewardAmount { get; internal set; }
 
         public CustomQuest()
         {

--- a/src/Quests/CustomQuest.cs
+++ b/src/Quests/CustomQuest.cs
@@ -7,6 +7,8 @@ using StardewModdingAPI;
 using StardewValley;
 using System;
 using System.Collections.Generic;
+using Microsoft.Xna.Framework.Graphics;
+using QuestFramework.Structures;
 
 namespace QuestFramework.Quests
 {
@@ -34,10 +36,13 @@ namespace QuestFramework.Quests
         public List<string> NextQuests { get; set; }
         public int Reward { get; set; }
         public RewardType RewardType { get; set; } = RewardType.Money;
+        public int RewardAmount { get; set; }
         public string RewardDescription { get; set; }
         public bool Cancelable { get; set; }
         public string ReactionText { get; set; }
         public int DaysLeft { get; set; } = 0;
+        public Texture2D Texture { get; set; }
+        public QuestLogColors Colors { get; set; }
         public List<Hook> Hooks { get; set; }
 
         public string Name
@@ -98,8 +103,6 @@ namespace QuestFramework.Quests
         internal protected static IModHelper Helper => QuestFrameworkMod.Instance.Helper;
         internal protected static IMonitor Monitor => QuestFrameworkMod.Instance.Monitor;
         private static StatsManager StatsManager => QuestFrameworkMod.Instance.StatsManager;
-
-        public int RewardAmount { get; internal set; }
 
         public CustomQuest()
         {

--- a/src/Quests/CustomQuest.cs
+++ b/src/Quests/CustomQuest.cs
@@ -44,6 +44,7 @@ namespace QuestFramework.Quests
         public Texture2D Texture { get; set; }
         public QuestLogColors Colors { get; set; }
         public List<Hook> Hooks { get; set; }
+        public Dictionary<string, string> Tags { get; }
 
         public string Name
         {
@@ -76,6 +77,29 @@ namespace QuestFramework.Quests
             return this.DaysLeft > 0;
         }
 
+        public int CustomTypeId 
+        { 
+            get => this.BaseType == QuestType.Custom ? this.customTypeId : -1; 
+            set => this.customTypeId = value >= 0 ? value : 0; 
+        }
+
+        internal protected static IModHelper Helper => QuestFrameworkMod.Instance.Helper;
+        internal protected static IMonitor Monitor => QuestFrameworkMod.Instance.Monitor;
+        private static StatsManager StatsManager => QuestFrameworkMod.Instance.StatsManager;
+
+        public CustomQuest()
+        {
+            this.BaseType = QuestType.Custom;
+            this.NextQuests = new List<string>();
+            this.Hooks = new List<Hook>();
+            this.Tags = new Dictionary<string, string>();
+        }
+
+        public CustomQuest(string name) : this()
+        {
+            this.Name = name;
+        }
+
         internal void ConfirmComplete(IQuestInfo questInfo)
         {
             StatsManager.AddCompletedQuest(this.GetFullName());
@@ -92,28 +116,6 @@ namespace QuestFramework.Quests
         {
             StatsManager.AddRemovedQuest(this.GetFullName());
             this.Removed?.Invoke(this, questInfo);
-        }
-
-        public int CustomTypeId 
-        { 
-            get => this.BaseType == QuestType.Custom ? this.customTypeId : -1; 
-            set => this.customTypeId = value >= 0 ? value : 0; 
-        }
-
-        internal protected static IModHelper Helper => QuestFrameworkMod.Instance.Helper;
-        internal protected static IMonitor Monitor => QuestFrameworkMod.Instance.Monitor;
-        private static StatsManager StatsManager => QuestFrameworkMod.Instance.StatsManager;
-
-        public CustomQuest()
-        {
-            this.BaseType = QuestType.Custom;
-            this.NextQuests = new List<string>();
-            this.Hooks = new List<Hook>();
-        }
-
-        public CustomQuest(string name) : this()
-        {
-            this.Name = name;
         }
 
         /// <summary>

--- a/src/Quests/RewardType.cs
+++ b/src/Quests/RewardType.cs
@@ -1,0 +1,8 @@
+﻿namespace QuestFramework.Quests
+{
+    public enum RewardType
+    {
+        Money = 2,
+        Item = 4,
+    }
+}

--- a/src/Quests/RewardType.cs
+++ b/src/Quests/RewardType.cs
@@ -3,6 +3,7 @@
     public enum RewardType
     {
         Money = 2,
-        Item = 4,
+        Object = 4,
+        Weapon = 8,
     }
 }

--- a/src/Structures/QuestLogColors.cs
+++ b/src/Structures/QuestLogColors.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuestFramework.Structures
+{
+    public class QuestLogColors
+    {
+        public int TitleColor { get; set; } = -1;
+        public int TextColor { get; set; } = -1;
+        public int ObjectiveColor { get; set; } = -1;
+    }
+}


### PR DESCRIPTION
This PR adds:

- Support for custom background texture and font colors for quest details window in quest log menu
- Support for new types of quest reward: `Object` and `Weapon`
- New fields for quest in content pack model: `RewardType`, `RewardAmount`, `Texture` and `Colors`
- New APIs for define quest reward type, custom bg texture nad font colors (C# code API)