### PR TITLE
Added monster reward fix and enhanced logging for action tiles

### DIFF
--- a/src/Framework/ContentPacks/Loader.cs
+++ b/src/Framework/ContentPacks/Loader.cs
@@ -159,9 +159,10 @@ namespace QuestFramework.Framework.ContentPacks
                     continue;
                 }
 
-                if (location.doesTileHaveProperty(dropBox.Value.Tile.X, dropBox.Value.Tile.Y, "Action", "Buildings") != null)
+                string previousAction = location.doesTileHaveProperty(dropBox.Value.Tile.X, dropBox.Value.Tile.Y, "Action", "Buildings");
+                if (previousAction != null)
                 {
-                    this.Monitor.Log($"({dropBox.Key.Manifest.UniqueID}) Cannot add drop box on tile `{dropBox.Value.Tile}` in `{dropBox.Value.Location}`: This tile is reserved for another action.", LogLevel.Error);
+                    this.Monitor.Log($"({dropBox.Key.Manifest.UniqueID}) Cannot add drop box on tile `{dropBox.Value.Tile}` in `{dropBox.Value.Location}`: This tile is reserved for another action (`{previousAction}`).", LogLevel.Error);
                     continue;
                 }
 

--- a/src/Patches/QuestPatch.cs
+++ b/src/Patches/QuestPatch.cs
@@ -38,11 +38,11 @@ namespace QuestFramework.Patches
 
                 if (__result != null && customQuest != null)
                 {
-                    if (customQuest.BaseType == QuestType.Monster && __result is SlayMonsterQuest)
+                    if (customQuest.BaseType == QuestType.Monster && __result is SlayMonsterQuest slayQuest)
                     {
                         // This is fix for use custom dialogue text for slay monster quest type
-                        (__result as SlayMonsterQuest).dialogueparts.Clear();
-                        (__result as SlayMonsterQuest).reward.Value = customQuest.Reward;
+                        slayQuest.dialogueparts.Clear();
+                        slayQuest.reward.Value = customQuest.Reward;
                     }
 
                     if (!Game1.player.hasQuest(id))

--- a/src/Patches/QuestPatch.cs
+++ b/src/Patches/QuestPatch.cs
@@ -42,6 +42,7 @@ namespace QuestFramework.Patches
                     {
                         // This is fix for use custom dialogue text for slay monster quest type
                         (__result as SlayMonsterQuest).dialogueparts.Clear();
+                        (__result as SlayMonsterQuest).reward.Value = customQuest.Reward;
                     }
 
                     if (!Game1.player.hasQuest(id))


### PR DESCRIPTION
Adds your fix for the monster quest reward. I tested it and it works. Also included Pathos suggestion to give a more meaningful error message when trying to add a drop box on top of an already occupied tile.